### PR TITLE
Fix incorrect http range headers

### DIFF
--- a/XvdTool.Streaming/HttpFileStream.cs
+++ b/XvdTool.Streaming/HttpFileStream.cs
@@ -51,7 +51,7 @@ public sealed class HttpFileStream : Stream
         var actualLength = Math.Min(Position + count, _contentLength);
 
         if (Position >= actualLength)
-            return new MemoryStream(Array.Empty<byte>());
+            return new MemoryStream([]);
 
         var header = new RangeHeaderValue(Position, actualLength - 1);
 
@@ -84,7 +84,7 @@ public sealed class HttpFileStream : Stream
         var actualLength = Math.Min(Position + count, _contentLength);
 
         if (Position >= actualLength)
-            return new MemoryStream(Array.Empty<byte>());
+            return new MemoryStream([]);
 
         var header = new RangeHeaderValue(Position, actualLength - 1);
 

--- a/XvdTool.Streaming/HttpFileStream.cs
+++ b/XvdTool.Streaming/HttpFileStream.cs
@@ -50,7 +50,10 @@ public sealed class HttpFileStream : Stream
     {
         var actualLength = Math.Min(Position + count, _contentLength);
 
-        var header = new RangeHeaderValue(Position, actualLength);
+        if (Position >= actualLength)
+            return new MemoryStream(Array.Empty<byte>());
+
+        var header = new RangeHeaderValue(Position, actualLength - 1);
 
 #if DEBUG
         Console.WriteLine($"Sending request to read from {Position} to {actualLength} (0x{actualLength - Position:x8})");
@@ -80,7 +83,10 @@ public sealed class HttpFileStream : Stream
     {
         var actualLength = Math.Min(Position + count, _contentLength);
 
-        var header = new RangeHeaderValue(Position, actualLength);
+        if (Position >= actualLength)
+            return new MemoryStream(Array.Empty<byte>());
+
+        var header = new RangeHeaderValue(Position, actualLength - 1);
 
 #if DEBUG
         Console.WriteLine($"Sending request to read from {Position} to {actualLength}");


### PR DESCRIPTION
The HttpFileStream implementation requested one extra byte during reads.